### PR TITLE
Enhance `dump_flash.py`

### DIFF
--- a/scripts/dump_flash.py
+++ b/scripts/dump_flash.py
@@ -11,46 +11,109 @@ if len(sys.argv) != 3:
     print("[x] Usage: %s [usb port] [output file]" % sys.argv[0])
     exit()
 
-# Memory map of the flash with the format "name": (address, size)
-flash_map = {
-    "BOOTING": (0x00000000, 148),
-    "UNUSED1": (0x00025000, 40),
-    "BOOTCFG": (0x0002f000, 4),
-    "FIRMWARE": (0x00030000, 3904),
-    "FIRMWARE2": (0x00400000, 3904),
-    "CONFIG": (0x007d0000, 64),
-    "ISPCONFIG": (0x007e0000, 64),
-    "UNUSED2": (0x007f0000, 40),
-    "EXPLOG": (0x007fa000, 16),
-    "PROFILE": (0x007fe000, 4),
-    "RADIO": (0x007ff000, 4)
-}
+def read_til_empty(s):
+    # Sleep to make sure we read everything
+    time.sleep(2)
+    while True:
+        if s.in_waiting > 0:
+            s.read(s.in_waiting)
+        else:
+            break
 
-mem_addr = 0x41b97d70   # Memory address where the flash memory regions will be copied
 max_dump_size = 16      # Maximum amount of memory that can be dumped (KB)
 
 max_dump_size_bytes = max_dump_size * 1024
 
 s = serial.Serial(sys.argv[1], BAUD_RATE)
+read_til_empty(s)
+
+
+# Get flash size
+s.write("flash -layout \r\n".encode("utf-8"))
+flash_size = s.read_until("Erase".encode("utf-8")).decode("utf-8")
+flash_size = int(flash_size.split("Total Size(K): ")[1].split("\r")[0])
+print("[+] Flash size: %sK" % flash_size)
+
+# Find free (biggest) memory address to read from flash
+# and also its size to do as few flash reads as possible
+mem_addr = 0
+max_read_size = 0
+
+read_til_empty(s)
+s.write("mem -show \r\n".encode("utf-8"))
+
+# On a failed read we might've corrupted the memory,
+# so a reboot COULD be required
+s.readline()
+s.readline()
+test_line = s.readline().decode("utf-8")
+if "wrong mem pool addr" not in test_line:
+    print("[+] Memory OK!")
+else:
+    # Reboot to get fresh new memory
+    print("[+] Memory corrupted. Rebooting router.")
+    s.write("system -reboot \r\n".encode("utf-8"))
+    print("[!] Sleeping for 30 seconds...")
+    time.sleep(30)
+    print("[+] Reboot complete!")
+    read_til_empty(s)
+    s.write("mem -show \r\n".encode("utf-8"))
+
+mem_addr_list = s.read_until("SUMMARY".encode("utf-8")).decode("utf-8")
+mem_addr_list = mem_addr_list.split("Heap Free Node:\r\n")[1]
+mem_addr_list = mem_addr_list.split("\r\n")[3:]
+for potential_mem_region in mem_addr_list:
+   data = potential_mem_region.split()
+   if potential_mem_region == '' or len(data) == 0:
+       break
+   potential_size = int(int(data[2]) / 1024)
+   if potential_size > max_read_size:
+       max_read_size = potential_size
+       mem_addr = int(data[1], 16)
+if max_read_size == 0:
+    print("[-] Couldn't find memory region to read flash")
+    exit(1)
+else:
+    # Just to be sure
+    max_read_size -= 1
+
+    # So we can find `end_segment`
+    mem_addr += 16 - (mem_addr % 16)
+
+    print("[+] Found free mem region at 0x%08x with size %sK" % (mem_addr, max_read_size))
 
 f = open(sys.argv[2], "wb")
-for region_name, region_data in flash_map.items():
 
-    print("[+] Copying %s from flash to memory" % region_name)
-    region_addr = region_data[0]
-    region_size = region_data[1]
-    region_size_bytes = region_size * 1024
-    copy_flash_cmd = "flash -read %02x %02x %02x\r\n" % (region_addr, region_size_bytes, mem_addr)
+flash_read_head = 0
+while flash_read_head < flash_size:
+    # Print progress
+    print("[!] Progress: %.2f%%" % (flash_read_head / flash_size))
+    # Read as much as possible
+    read_size = max_read_size
+    # Unless we are apporaching the end of the flash
+    if flash_size - flash_read_head < read_size:
+        read_size = flash_size - flash_read_head
+
+    read_start = flash_read_head * 1024
+    read_end = read_start + read_size
+    print("[+] Copying 0x%08x -> 0x%08x (%sK) from flash to memory" % (read_start, read_end, read_size))
+
+    # Update head
+    flash_read_head += read_size
+
+    # Convert to bytes
+    read_size *= 1024
+
+    copy_flash_cmd = "flash -read %02x %02x %02x\r\n" % (read_start, read_size, mem_addr)
     s.write(copy_flash_cmd.encode("utf-8"))
-    s.readline().decode("utf-8")
-    s.readline().decode("utf-8")
-    
+    read_til_empty(s);
+
     bytes_read = 0
-    while bytes_read < region_size_bytes:
+    while bytes_read < read_size:
 
         start_fragment = mem_addr + bytes_read
 
-        bytes_left = (region_size_bytes - bytes_read)
+        bytes_left = (read_size - bytes_read)
 
         if bytes_left >= max_dump_size_bytes:
             end_fragment = start_fragment + max_dump_size_bytes - 16
@@ -62,10 +125,10 @@ for region_name, region_data in flash_map.items():
         bytes_read += bytes_to_read
 
         dump_mem_cmd = "mem -dump %02x %02x\r\n" % (start_fragment, bytes_to_read)
-        print("[+] Dumping memory region from %s to %s" % (hex(start_fragment), hex(end_fragment)))   
+        print("[+] Dumping memory region from %s to %s" % (hex(start_fragment), hex(end_fragment)))
         s.write(dump_mem_cmd.encode("utf-8"))
         s.readline().decode("utf-8")
-        
+
         # Read a line until the last address of this region is read
         try:
             line = None


### PR DESCRIPTION
Hello!

I am currently doing some reverse engineering on another router model, and I wanted to use your script to dump the firmware but I ran into a little issue:

The biggest flash region inside my model is the `FIRMWARE` sitting at 1900KB, while the biggest free memory region I had was way below that, so I couldn't use the script since I could never copy the entire `FIRMWARE` region.

I have modified it with the following features:
* Get flash size automatically
* Get the address of the biggest free heap memory region automatically
* If we cannot get the region, reboot the router automatically and retry
* Instead of copying entire regions from flash to memory, copy max amount constrained by the memory size.

The rest is unchanged. I also removed the `flash_map` since it was no longer necessary.

Please feel free to test it on your router as well and let me know if it works well, or if you encounter any issues.

Thanks a lot for this script :) looking forward to analysing the dumped flash and the firmware.

Have a great day!